### PR TITLE
Move "scalability" to top-level criteria

### DIFF
--- a/_microservices/criteria/reliability.md
+++ b/_microservices/criteria/reliability.md
@@ -6,9 +6,6 @@ position: 1
 ## Reliability
 A reliable service is one that is available when it's needed and that suffers from limited downtime. Keep the following in mind when designing a reliable microservice.
 
-### Scalability
-- Have you calculated the extremes of request rates, and can you service tolerate them? A good example is ATXFloods, a service which experiences massive peaks at precisely the time it is most critical to its users. Its architecture must be able to accommodate an increased response rate several orders of magnitude higher than the traffic it experiences 99% of the year.
-
 ### Monitoring
 - How will you know if the service is down? Do you have proactive error logging and reporting or do you rely on consumers of the service to inform you of an outage?
 
@@ -16,3 +13,9 @@ A reliable service is one that is available when it's needed and that suffers fr
 
 - How quickly does your service process requests?
 - Do you have timeouts set so your service does not hang indefinitely on a single failed request or response?
+
+### Scalability
+
+- Have you identified extremes of server requests and data transfer?
+- Are there other dependncies like 3rd-party API rate limits that might be a bottleneck in your application?
+- Read more in the [scalability guide](../scalability)

--- a/_microservices/criteria/scalability.md
+++ b/_microservices/criteria/scalability.md
@@ -1,0 +1,8 @@
+---
+title: Scalability
+position: 4
+---
+
+## Scalability
+
+Have you calculated the extremes of request rates, and can you service tolerate them? A good example is ATXFloods, a service which experiences massive peaks at precisely the time it is most critical to its users. Its architecture must be able to accommodate an increased response rate several orders of magnitude higher than the traffic it experiences 99% of the year.


### PR DESCRIPTION
I had originally placed this within the "reliability" section since, in my mind, scalability is a core element of a reliable system. However, Amenity suggested it be moved to a more prominent position at the same IA level as "reliability" to make it more visible.