### PR TITLE
Add reference to GDS technology service manual

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,3 +14,7 @@ These guides are helpful for:
 - **CoA web developers** who want to follow best practices in their day-to-day work and strategic decision-making
 - **Technology procurers or technical vendor relationship managers** who are exploring new or amended solutions to their digital needs
 - **Other governments** who want some insight into how Austin is thinking about web development
+
+## Technology Service Manual
+
+The [Technology Service Manual](https://www.gov.uk/service-manual/technology) consists of tactical and strategic guidelines for delivering digital services in government. Created by the [UK Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service), it outlines best-practices across a range of domains, from software testing to application monitoring. Read it. It's great.


### PR DESCRIPTION
After speaking with Paul Bowsher (dev lead on Gov.uk) we learned about GDS's approach to enforcement of best practices via these guides. Rather than re-create them for ourselves we decided it made more sense to reference their guides for the high-level strategic stuff, and to focus our own guides on the more tactical elements like how to gain access to CTM cloud services and how to share credentials with other CoA employees who work in a governance capacity.